### PR TITLE
Allow specified keys to be downloaded

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,16 +34,20 @@ $ humblebundle-ebook-downloader --help
   Usage: humblebundle-ebook-downloader [options]
 
   Options:
-
     -V, --version                              output the version number
-    -d, --download-folder <downloader_folder>  Download folder (default: download)
+    -d, --download-folder <downloader_folder>  Download folder (default: "download")
     -l, --download-limit <download_limit>      Parallel download limit (default: 1)
-    -f, --format <format>                      What format to download the ebook in (all, cbz, epub, mobi, pdf, pdf_hd) (default: epub)
-    --auth-token <auth-token>                  Optional: If you want to run headless, you can specify your authentication cookie from your browser (_simpleauth_sess)
+    -f, --format <format>                      What format to download the ebook in (all, cbz, epub, mobi, pdf, pdf_hd)
+                                               (default: "epub")
+    --auth-token <auth-token>                  Optional: If you want to run headless, you can specify your authentication
+                                               cookie from your browser (_simpleauth_sess)
+    -k, --keys <keys>                          Comma-separated list of specific purchases to download
     -a, --all                                  Download all bundles
-    --debug                                    Enable debug logging
-    -h, --help                                 output usage information
+    --debug                                    Enable debug logging (default: false)
+    -h, --help                                 display help for command
 ```
+
+Keys should be specified as a list like `gamekey1,gamekey2,gamekey3`. They can be found by opening a bundle from the [Purchased Products](https://www.humblebundle.com/home/purchases) page; the key will be in the url `https://www.humblebundle.com/downloads?key=gamekey1`.
 
 ## Contributors
 - [J. Longman](https://github.com/jlongman)

--- a/index.mjs
+++ b/index.mjs
@@ -167,7 +167,6 @@ async function fetchOrders (session) {
   let fetchKeys
 
   if (options.keys) {
-    console.log('🚀 ~ file: index.mjs ~ line 170 ~ fetchOrders ~ options.keys', options.keys)
     const specifiedKeys = options.keys.split(',')
     specifiedKeys.forEach(key => {
       if (!allKeys.includes(key)) {

--- a/index.mjs
+++ b/index.mjs
@@ -33,6 +33,7 @@ commander
   .option('-l, --download-limit <download_limit>', 'Parallel download limit', 1)
   .option('-f, --format <format>', util.format('What format to download the ebook in (%s)', ALLOWED_FORMATS.join(', ')), 'epub')
   .option('--auth-token <auth-token>', 'Optional: If you want to run headless, you can specify your authentication cookie from your browser (_simpleauth_sess)')
+  .option('-k, --keys <keys>', 'Comma-separated list of specific purchases to download')
   .option('-a, --all', 'Download all bundles')
   .option('--debug', 'Enable debug logging', false)
   .parse()
@@ -159,13 +160,30 @@ async function fetchOrders (session) {
     throw new Error(util.format('Could not fetch orders, unknown error, status code:', response.statusCode))
   }
 
-  const allBundles = JSON.parse(response.body)
+  const allKeys = JSON
+    .parse(response.body)
+    .map(bundle => bundle.gamekey)
 
-  const total = allBundles.length
+  let fetchKeys
+
+  if (options.keys) {
+    console.log('🚀 ~ file: index.mjs ~ line 170 ~ fetchOrders ~ options.keys', options.keys)
+    const specifiedKeys = options.keys.split(',')
+    specifiedKeys.forEach(key => {
+      if (!allKeys.includes(key)) {
+        throw new Error(util.format('Invalid key %s', key))
+      }
+    })
+    fetchKeys = specifiedKeys
+  } else {
+    fetchKeys = allKeys
+  }
+
+  const total = fetchKeys.length
   let done = 0
   const orders = []
 
-  for (const { gamekey } of allBundles) {
+  for (const gamekey of fetchKeys) {
     const bundle = await got.get(util.format('https://www.humblebundle.com/api/v1/order/%s?ajax=true', gamekey), {
       headers: getRequestHeaders(session)
     })


### PR DESCRIPTION
We add a `--keys` option which allows bundle keys to be specified, and only these bundles will be fetched. This means if we have specific bundles we want to download, we can simply provide those keys instead of waiting for every bundle to be fetched.