### PR TITLE
Fix unusual formats

### DIFF
--- a/index.mjs
+++ b/index.mjs
@@ -239,7 +239,7 @@ function normalizeFormat (format) {
     case 'pdf (hd)':
       return 'pdf_hd'
     case 'download':
-      return 'pdf'
+      return 'download'
     default:
       return format.toLowerCase()
   }
@@ -250,6 +250,7 @@ function getExtension (format) {
     case 'pdf_hd':
       return ' (hd).pdf'
     case 'supplement':
+    case 'download':
       return '.zip'
     default:
       return util.format('.%s', format)

--- a/index.mjs
+++ b/index.mjs
@@ -249,6 +249,8 @@ function getExtension (format) {
   switch (format.toLowerCase()) {
     case 'pdf_hd':
       return ' (hd).pdf'
+    case 'supplement':
+      return '.zip'
     default:
       return util.format('.%s', format)
   }


### PR DESCRIPTION
Some book bundles contain supplemental material in zip files, where the format is specified as "Supplement", "Download", etc. These are not being handled correctly:
- Supplements are given the extension `.supplement`
- Downloads are given the extension `.pdf`

We therefore fix this to handle these formats correctly.