### PR TITLE
Download items marked as video

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ $ humblebundle-ebook-downloader --help
     -l, --download-limit <download_limit>      Parallel download limit (default: 1)
     -f, --format <format>                      What format to download the ebook in (all, cbz, epub, mobi, pdf, pdf_hd)
                                                (default: "epub")
-    -v, --video                                Download supplements marked as video (default: false)
+    -v, --video                                Download items marked as video (default: false)
     --auth-token <auth-token>                  Optional: If you want to run headless, you can specify your authentication
                                                cookie from your browser (_simpleauth_sess)
     -k, --keys <keys>                          Comma-separated list of specific purchases to download

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ $ humblebundle-ebook-downloader --help
     -l, --download-limit <download_limit>      Parallel download limit (default: 1)
     -f, --format <format>                      What format to download the ebook in (all, cbz, epub, mobi, pdf, pdf_hd)
                                                (default: "epub")
+    -v, --video                                Download supplements marked as video (default: false)
     --auth-token <auth-token>                  Optional: If you want to run headless, you can specify your authentication
                                                cookie from your browser (_simpleauth_sess)
     -k, --keys <keys>                          Comma-separated list of specific purchases to download

--- a/index.mjs
+++ b/index.mjs
@@ -32,6 +32,7 @@ commander
   .option('-d, --download-folder <downloader_folder>', 'Download folder', 'download')
   .option('-l, --download-limit <download_limit>', 'Parallel download limit', 1)
   .option('-f, --format <format>', util.format('What format to download the ebook in (%s)', ALLOWED_FORMATS.join(', ')), 'epub')
+  .option('-v, --video', 'Download supplements marked as video', false)
   .option('--auth-token <auth-token>', 'Optional: If you want to run headless, you can specify your authentication cookie from your browser (_simpleauth_sess)')
   .option('-k, --keys <keys>', 'Comma-separated list of specific purchases to download')
   .option('-a, --all', 'Download all bundles')
@@ -282,7 +283,7 @@ async function processBundles (bundles) {
 
     for (const subproduct of bundle.subproducts) {
       const filteredDownloads = subproduct.downloads.filter((download) => {
-        return download.platform === 'ebook'
+        return requiredPlatform(download.platform)
       })
 
       const downloadStructs = keypath
@@ -331,6 +332,12 @@ async function processBundles (bundles) {
   totalDownloads = downloads.length
 
   return PMap(downloads, downloadEbook, { concurrency: 5 })
+}
+
+function requiredPlatform (platform) {
+  return options.video
+    ? platform === 'ebook' || 'video'
+    : platform === 'ebook'
 }
 
 async function downloadEbook (download) {

--- a/index.mjs
+++ b/index.mjs
@@ -32,7 +32,7 @@ commander
   .option('-d, --download-folder <downloader_folder>', 'Download folder', 'download')
   .option('-l, --download-limit <download_limit>', 'Parallel download limit', 1)
   .option('-f, --format <format>', util.format('What format to download the ebook in (%s)', ALLOWED_FORMATS.join(', ')), 'epub')
-  .option('-v, --video', 'Download supplements marked as video', false)
+  .option('-v, --video', 'Download items marked as video', false)
   .option('--auth-token <auth-token>', 'Optional: If you want to run headless, you can specify your authentication cookie from your browser (_simpleauth_sess)')
   .option('-k, --keys <keys>', 'Comma-separated list of specific purchases to download')
   .option('-a, --all', 'Download all bundles')


### PR DESCRIPTION
Some book bundles include videos -- for example, **Humble Book Bundle: Front End Web Development by Packt** and **Humble Book Bundle: iOS & Android Mobile Development by Packt** both include video tutorials. However the way Humble Bundle have marked these is inconsistent. The **Front End Web Development** bundle includes them in the eBook section, while the **iOS & Android Mobile Development** bundle has them in a separate video section.

We want to be able to download these video tutorials, so we add a `--video` option which will also include downloads in the separate video section (defaulting to not downloading them). Unfortunately there's no way we can identify videos if they're included in the eBook section; those videos will always be downloaded, regardless of whether or not `--video` is set.

Note that this will still only download bundles containing one or more items marked as an eBook; any bundles which are purely video-only (eg. VFX bundles) will not be downloaded.