### PR TITLE
Improved bundle fetching & filtering

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ $ humblebundle-ebook-downloader --help
     -l, --download-limit <download_limit>      Parallel download limit (default: 1)
     -f, --formats <formats>                    Comma-separated list of formats to download (all, cbz, epub, mobi, pdf, pdf_hd, prc,
                                                video) (default: "pdf")
+    --filter <filter>                          Only display bundles with this text in the title
     --auth-token <auth-token>                  Optional: If you want to run headless, you can specify your authentication cookie
                                                from your browser (_simpleauth_sess)
     -k, --keys <keys>                          Comma-separated list of specific purchases to download

--- a/index.mjs
+++ b/index.mjs
@@ -32,7 +32,7 @@ commander
   .option('-d, --download-folder <downloader_folder>', 'Download folder', 'download')
   .option('-l, --download-limit <download_limit>', 'Parallel download limit', 1)
   .option('-f, --formats <formats>', util.format('Comma-separated list of formats to download (%s)', ALLOWED_FORMATS.join(', ')), 'pdf')
-  .option('--filter <filter>', 'Only retrieve bundles with this text in the title')
+  .option('--filter <filter>', 'Only display bundles with this text in the title')
   .option('--auth-token <auth-token>', 'Optional: If you want to run headless, you can specify your authentication cookie from your browser (_simpleauth_sess)')
   .option('-k, --keys <keys>', 'Comma-separated list of specific purchases to download')
   .option('-a, --all', 'Download all bundles')

--- a/index.mjs
+++ b/index.mjs
@@ -192,9 +192,16 @@ async function fetchOrders (session) {
   // This is the endpoint used by https://www.humblebundle.com/home/purchases
 
   // We cut the keys array into 40-key chunks as this is the max number of keys we can fetch from the endpoint
-  const chunkedKeys = chunkArray(fetchKeys, 40)
+  const chunkSize = 40
+  const chunkedKeys = chunkArray(fetchKeys, chunkSize)
 
-  for (const chunk of chunkedKeys) {
+  for (const [index, chunk] of chunkedKeys.entries()) {
+    console.log(util.format('Fetching bundle details... (%s-%s/%s)',
+      colors.yellow(index * chunkSize + 1),
+      colors.yellow(Math.min((index + 1) * chunkSize, fetchKeys.length + 1)),
+      colors.yellow(fetchKeys.length + 1)
+    ))
+
     // The endpoint takes keys in the format `gamekeys=...&gamekeys=...&gamekeys=...` so assemble a string of this
     const gamekeysString = chunk
       .map(gamekey => `gamekeys=${gamekey}`)
@@ -218,11 +225,6 @@ async function fetchOrders (session) {
         orders.push(order)
       }
     })
-
-    console.log(util.format('Fetched bundle information chunk... (%s/%s)',
-      colors.yellow(chunkedKeys.indexOf(chunk) + 1),
-      colors.yellow(chunkedKeys.length)
-    ))
   }
 
   // Filter out any orders which don't have an ebook section
@@ -250,7 +252,7 @@ async function displayOrders (orders) {
     .map(order => order.product.human_name)
     .sort((a, b) => a.localeCompare(b))
 
-  // process.stdout.write('\x1Bc') // Clear console
+  process.stdout.write('\x1Bc') // Clear console
 
   const answers = await inquirer.prompt({
     type: 'checkbox',


### PR DESCRIPTION
So far we have fetched bundle info for one bundle at at time. However there is another API we can use which fetches the info for up to 40 bundles at a time, which drastically reduces the time taken to fetch all the bundle info (in our tests we found it to be 5x faster, reducing the time taken from ~99s to ~20s).

We therefore rework the bundle fetching to use this endpoint. We also implement a filter option, which will only display bundles with the specified text in the bundle name. Note that we still have to fetch all bundles, as the endpoint we use to get the purchased bundles only returns a list of keys; we still need to fetch each one in order to get their names so we can filter them.