### PR TITLE
Replace `colors` with `chalk`

### DIFF
--- a/index.mjs
+++ b/index.mjs
@@ -8,8 +8,8 @@ import { resolve } from 'path'
 import { pipeline } from 'stream/promises'
 import util from 'util'
 
+import chalk from 'chalk'
 import commander from 'commander'
-import colors from 'colors'
 import got from 'got'
 import hasha from 'hasha'
 import inquirer from 'inquirer'
@@ -49,14 +49,14 @@ const formatsToDownload = options.formats.split(',')
 
 formatsToDownload.forEach(format => {
   if (ALLOWED_FORMATS.indexOf(format) === -1) {
-    console.error(colors.red('Invalid format selected.'))
+    console.error(chalk.red('Invalid format selected.'))
     commander.help()
   }
 })
 
 const configPath = resolve(homedir(), '.humblebundle_ebook_downloader.json')
 
-console.log(colors.green('Starting...'))
+console.log(chalk.green('Starting...'))
 
 main()
 
@@ -122,7 +122,7 @@ async function saveConfig (config, callback) {
 
 function debug () {
   if (commander.debug) {
-    console.log(colors.yellow('[DEBUG] ' + util.format.apply(this, arguments)))
+    console.log(chalk.yellow('[DEBUG] ' + util.format.apply(this, arguments)))
   }
 }
 
@@ -196,9 +196,9 @@ async function fetchOrders (session) {
 
   for (const [index, chunk] of chunkedKeys.entries()) {
     console.log(util.format('Fetching bundle details... (%s-%s/%s)',
-      colors.yellow(index * chunkSize + 1),
-      colors.yellow(Math.min((index + 1) * chunkSize, fetchKeys.length + 1)),
-      colors.yellow(fetchKeys.length + 1)
+      chalk.yellow(index * chunkSize + 1),
+      chalk.yellow(Math.min((index + 1) * chunkSize, fetchKeys.length + 1)),
+      chalk.yellow(fetchKeys.length + 1)
     ))
 
     // The endpoint takes keys in the format `gamekeys=...&gamekeys=...&gamekeys=...` so assemble a string of this
@@ -312,7 +312,7 @@ async function checkSignatureMatch (filePath, download) {
 
 async function processBundles (bundles) {
   if (!bundles.length) {
-    console.log(colors.green('No bundles selected, exiting'))
+    console.log(chalk.green('No bundles selected, exiting'))
     return
   }
 
@@ -362,7 +362,7 @@ async function processBundles (bundles) {
 
     if (!bundleDownloads.length) {
       console.log(
-        colors.red('No downloads found matching the right format%s (%s) for bundle (%s), available format%s: (%s)'),
+        chalk.red('No downloads found matching the right format%s (%s) for bundle (%s), available format%s: (%s)'),
         pluralise(formatsToDownload),
         formatsToDownload.join(', '),
         bundleName,
@@ -378,7 +378,7 @@ async function processBundles (bundles) {
 
   if (!downloads.length) {
     console.log(
-      colors.red('No downloads found matching the right format%s (%s), exiting'),
+      chalk.red('No downloads found matching the right format%s (%s), exiting'),
       pluralise(formatsToDownload),
       formatsToDownload.join(', ')
     )
@@ -443,8 +443,8 @@ async function downloadEbook (download) {
       download.name,
       download.adjustedFormat,
       download.download.human_size,
-      colors.yellow(++doneDownloads),
-      colors.yellow(totalDownloads)
+      chalk.yellow(++doneDownloads),
+      chalk.yellow(totalDownloads)
     )
   }
 }
@@ -472,8 +472,8 @@ async function doDownload (filePath, download) {
     download.name,
     download.adjustedFormat,
     download.download.human_size,
-    colors.yellow(++doneDownloads),
-    colors.yellow(totalDownloads)
+    chalk.yellow(++doneDownloads),
+    chalk.yellow(totalDownloads)
   )
 }
 
@@ -495,10 +495,10 @@ async function main () {
 
     await processBundles(bundles)
     await Promise.all(downloadPromises)
-    console.log(colors.green('Done!'))
+    console.log(chalk.green('Done!'))
     process.exit(1)
   } catch (error) {
-    console.error(colors.red('An error occured, exiting.'))
+    console.error(chalk.red('An error occured, exiting.'))
     console.error(error)
     process.exit(1)
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.18",
       "license": "Unlicense",
       "dependencies": {
-        "colors": "^1.4.0",
+        "chalk": "^5.0.0",
         "commander": "^8.3.0",
         "got": "^12.0.0",
         "hasha": "^5.2.2",
@@ -60,6 +60,20 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/highlight/node_modules/chalk": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^3.2.1",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^5.3.0"
+      },
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/@eslint/eslintrc": {
@@ -485,17 +499,14 @@
       }
     },
     "node_modules/chalk": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-      "dev": true,
-      "dependencies": {
-        "ansi-styles": "^3.2.1",
-        "escape-string-regexp": "^1.0.5",
-        "supports-color": "^5.3.0"
-      },
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.0.0.tgz",
+      "integrity": "sha512-/duVOqst+luxCQRKEo4bNxinsOQtMP80ZYm7mMqzuh5PociNL0PvmHFvREJ9ueYL2TxlHjBcmLCdmocx9Vg+IQ==",
       "engines": {
-        "node": ">=4"
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "node_modules/chardet": {
@@ -588,14 +599,6 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
       "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
       "dev": true
-    },
-    "node_modules/colors": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz",
-      "integrity": "sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==",
-      "engines": {
-        "node": ">=0.1.90"
-      }
     },
     "node_modules/commander": {
       "version": "8.3.0",
@@ -4022,6 +4025,19 @@
         "@babel/helper-validator-identifier": "^7.15.7",
         "chalk": "^2.0.0",
         "js-tokens": "^4.0.0"
+      },
+      "dependencies": {
+        "chalk": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        }
       }
     },
     "@eslint/eslintrc": {
@@ -4333,15 +4349,9 @@
       "dev": true
     },
     "chalk": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-      "dev": true,
-      "requires": {
-        "ansi-styles": "^3.2.1",
-        "escape-string-regexp": "^1.0.5",
-        "supports-color": "^5.3.0"
-      }
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.0.0.tgz",
+      "integrity": "sha512-/duVOqst+luxCQRKEo4bNxinsOQtMP80ZYm7mMqzuh5PociNL0PvmHFvREJ9ueYL2TxlHjBcmLCdmocx9Vg+IQ=="
     },
     "chardet": {
       "version": "0.7.0",
@@ -4408,11 +4418,6 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
       "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
       "dev": true
-    },
-    "colors": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz",
-      "integrity": "sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA=="
     },
     "commander": {
       "version": "8.3.0",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   },
   "author": "David Marby <david@dmarby.se> http://dmarby.se",
   "dependencies": {
-    "colors": "^1.4.0",
+    "chalk": "^5.0.0",
     "commander": "^8.3.0",
     "got": "^12.0.0",
     "hasha": "^5.2.2",


### PR DESCRIPTION
Due to [recent events](https://www.bleepingcomputer.com/news/security/dev-corrupts-npm-libs-colors-and-faker-breaking-thousands-of-apps/), we replace the [`colors`](https://www.npmjs.com/package/colors) dependency with [`chalk`](https://www.npmjs.com/package/chalk).