### PR TITLE
Fix authentication error being thrown

### DIFF
--- a/index.mjs
+++ b/index.mjs
@@ -102,7 +102,8 @@ async function validateSession (config) {
   }
 
   const { statusCode } = await got.get('https://www.humblebundle.com/api/v1/user/order?ajax=true', {
-    headers: getRequestHeaders(session)
+    headers: getRequestHeaders(session),
+    throwHttpErrors: false
   })
 
   if (statusCode === 200) {


### PR DESCRIPTION
We hadn't realised that `got` throws an error if an http error is encountered. We want to handle non-2xx errors ourselves so we disable this behaviour.