### PR TITLE
Fix fetch number

### DIFF
--- a/index.mjs
+++ b/index.mjs
@@ -159,7 +159,8 @@ async function fetchOrders (session) {
 
   // Fetch the list of gamekeys
   const keysResponse = await got.get('https://www.humblebundle.com/api/v1/user/order?ajax=true', {
-    headers: getRequestHeaders(session)
+    headers: getRequestHeaders(session),
+    throwHttpErrors: false
   })
 
   if (keysResponse.statusCode !== 200) {

--- a/index.mjs
+++ b/index.mjs
@@ -199,8 +199,8 @@ async function fetchOrders (session) {
   for (const [index, chunk] of chunkedKeys.entries()) {
     console.log(util.format('Fetching bundle details... (%s-%s/%s)',
       chalk.yellow(index * chunkSize + 1),
-      chalk.yellow(Math.min((index + 1) * chunkSize, fetchKeys.length + 1)),
-      chalk.yellow(fetchKeys.length + 1)
+      chalk.yellow(Math.min((index + 1) * chunkSize, fetchKeys.length)),
+      chalk.yellow(fetchKeys.length)
     ))
 
     // The endpoint takes keys in the format `gamekeys=...&gamekeys=...&gamekeys=...` so assemble a string of this


### PR DESCRIPTION
We noticed that the end values of the `Fetching bundle` message were wrong, eg. if fetching 3 bundles it would display `(1-4/4)`. We remove the `+ 1` from the 'to' value and the end value to fix this.

We also spotted another place we should add `throwHttpErrors: false` to a `got` request to enable us to handle non-2xx errors ourselves, so we fix this here.