### PR TITLE
Add option to sort by date in menu

### DIFF
--- a/index.js
+++ b/index.js
@@ -236,7 +236,6 @@ async function fetchOrders (session) {
         .flat()
         .indexOf('ebook') !== -1
     })
-    .sort((a, b) => a.product.human_name.localeCompare(b.product.human_name))
 }
 
 function chunkArray (array, size) {

--- a/index.js
+++ b/index.js
@@ -34,6 +34,7 @@ commander
   .option('--filter <filter>', 'Only display bundles with this text in the title')
   .option('--auth-token <auth-token>', 'Optional: If you want to run headless, you can specify your authentication cookie from your browser (_simpleauth_sess)')
   .option('-k, --keys <keys>', 'Comma-separated list of specific purchases to download')
+  .option('-s, --sort <sort>', 'Order to sort bundles in menu (name, date)', 'name')
   .option('-a, --all', 'Download all bundles')
   .option('--debug', 'Enable debug logging', false)
   .parse()
@@ -236,6 +237,18 @@ async function fetchOrders (session) {
         .flat()
         .indexOf('ebook') !== -1
     })
+    .sort((a, b) => sortBundles(a, b, options.sort))
+}
+
+function sortBundles (a, b, sortOrder) {
+  switch (sortOrder) {
+    case 'name':
+      return a.product.human_name.localeCompare(b.product.human_name)
+    case 'date':
+      // We use the created date, which is stored as a string so we can use localeCompare()
+      // We compare b with a to so that we sort in reverse order (ie. latest bundle first)
+      return b.created.localeCompare(a.created)
+  }
 }
 
 function chunkArray (array, size) {

--- a/package.json
+++ b/package.json
@@ -2,9 +2,9 @@
   "name": "humblebundle-ebook-downloader",
   "version": "1.0.18",
   "license": "Unlicense",
-  "main": "index.mjs",
+  "main": "index.js",
   "bin": {
-    "humblebundle-ebook-downloader": "index.mjs"
+    "humblebundle-ebook-downloader": "index.js"
   },
   "scripts": {
     "test": "standard"
@@ -28,5 +28,6 @@
   },
   "devDependencies": {
     "standard": "^16.0.4"
-  }
+  },
+  "type": "module"
 }


### PR DESCRIPTION
We add a `--sort` option which allows us to specify the sort order. It defaults to `name` and also allows `date`, which sorts in date order (newest first). We can now easily download the bundles we most recently bought, without needing to manually specify the keys.

While making this change we also change the filename from `index.mjs` to `index.js`, and add `"type": "module"` to `package.json`.